### PR TITLE
Init service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 .project
 .settings
+.vscode
 TAGS
 bower_components
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-mail ChangeLog
 
+## 3.0.2 - TBD
+
+### Fixed
+- Properly initialize the `bedrock.config.mail.locals.service` namespace.
+
 ## 3.0.1 - 2021-05-06
 
 ### Changed

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,12 @@ config.mail.templates.paths = [];
 config.mail.message = {};
 
 // default locals for all templates
-config.mail.locals = {};
+config.mail.locals = {
+  service: {
+    name: 'Bedrock Default Service Name',
+    url: 'https://example.com/'
+  }
+};
 
 // force mail to field for development use)
 // email address string


### PR DESCRIPTION
`config.mail.locals.service` was not being initialized and therefore it was no possible to directly set with:
```
config.mail.locals.service.name = 'foo'
config.mail.locals.service.url = 'https://bar.com'
```

This in particular impacted the use of Bedrock's computed config API.