### PR TITLE
Reduce dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-mail ChangeLog
 
+## 6.1.0 - 2025-mm-dd
+
+### Changed
+- Reduce dependencies by removing unsupported/unusable template renderers.
+
 ## 6.0.0 - 2024-10-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # bedrock-mail ChangeLog
 
-## 6.1.0 - 2025-mm-dd
+## 7.0.0 - 2025-mm-dd
 
 ### Changed
-- Reduce dependencies by removing unsupported/unusable template renderers.
+- **BREAKING**: Reduce dependencies by removing unsupported/unusable template
+  renderers. Note that this is not strictly breaking (nor expected to break
+  anything with a direct upgrade), a major release may help avoid unforeseen
+  problems with this significant upgrade.
 
 ## 6.0.0 - 2024-10-15
 

--- a/lib/EmailClient.js
+++ b/lib/EmailClient.js
@@ -24,7 +24,7 @@ const env = (process.env.NODE_ENV ?? 'development').toLowerCase();
 const CACHE = ['development', 'test'].includes(env) ?
   undefined : new LRU({max: 100});
 
-const TEMPLATE_EXTENSION = 'ejs';
+const TEMPLATE_EXTENSION = '.ejs';
 
 export class EmailClient {
   constructor({
@@ -127,22 +127,29 @@ export class EmailClient {
   // convert a template name to a full file path
   _getTemplateFilePath({templateName} = {}) {
     // `templateName` format is either:
-    // 1. absolute file path w/o the extension
+    // 1. absolute file path w/ or w/o the extension
     // 2. <templateName>/<subject|html|text>
     const [root, basename] = path.isAbsolute(templateName) ?
       [path.dirname(templateName), path.basename(templateName)] :
       [this.config.templateRootPath, templateName];
-    return path.join(root, basename, TEMPLATE_EXTENSION);
+    let filePath = path.join(root, basename);
+    if(!filePath.endsWith(TEMPLATE_EXTENSION)) {
+      filePath += TEMPLATE_EXTENSION;
+    }
+    return filePath;
   }
 
   // render a template file
   async _render({filePath, locals = {}} = {}) {
     // get cached compiled template/compile template
-    let renderFn = this.config.cache ?? CACHE.get(filePath);
+    let renderFn = this.config.cache && CACHE.get(filePath);
     if(!renderFn) {
       try {
         const content = await readFile(filePath, 'utf8');
         renderFn = ejs.compile(content, {async: true});
+        if(this.config.cache) {
+          CACHE.set(filePath, renderFn);
+        }
       } catch(cause) {
         const error = new BedrockError(
           `Could not compile email template "${filePath}": ${cause.message}`, {
@@ -154,7 +161,7 @@ export class EmailClient {
       }
     }
 
-    return renderFn(filePath, locals);
+    return renderFn(locals);
   }
 
   // renders a component of a message, if a template file for it exists
@@ -169,10 +176,8 @@ export class EmailClient {
     return this._render({filePath, locals});
   }
 
-  async _templateFileExists({templateName, component} = {}) {
+  async _templateFileExists({filePath} = {}) {
     try {
-      const name = path.join(templateName, component);
-      const filePath = this.getTemplatePath({templateName: name});
       const stats = await stat(filePath);
       if(!stats.isFile()) {
         const error = new BedrockError(

--- a/lib/EmailClient.js
+++ b/lib/EmailClient.js
@@ -146,7 +146,13 @@ export class EmailClient {
     if(!renderFn) {
       try {
         const content = await readFile(filePath, 'utf8');
-        renderFn = ejs.compile(content, {async: true});
+        renderFn = ejs.compile(content, {
+          // note: including files is currently not possible in `async` mode
+          //async: true,
+          // enable `includes` in templates
+          root: this.config.templateRootPath,
+          views: [path.dirname(filePath)]
+        });
         if(this.config.cache) {
           CACHE.set(filePath, renderFn);
         }

--- a/lib/EmailClient.js
+++ b/lib/EmailClient.js
@@ -85,7 +85,7 @@ export class EmailClient {
 
     // throw error for totally blank message
     if(!(message.subject || message.html || message.text ||
-      message.attachments.length > 0)) {
+      message.attachments?.length > 0)) {
       const error = new BedrockError(
         `No message content detected for template "${template}"; ` +
         '(no "subject", "html", "text", nor "attachments").', {
@@ -100,10 +100,7 @@ export class EmailClient {
 
   async send(options = {}) {
     const {template = ''} = options;
-    const locals = {
-      ...this.config.views.locals,
-      ...options.locals
-    };
+    const locals = {...options.locals};
 
     // construct fully rendered message
     let message = {
@@ -112,7 +109,7 @@ export class EmailClient {
       attachments: options.message.attachments ??
         this.config.message.attachments ?? []
     };
-    message = await this.renderMessage(template, locals, message);
+    message = await this.renderMessage({template, locals, message});
 
     // preview email in a browser
     if(this.config.preview) {

--- a/lib/EmailClient.js
+++ b/lib/EmailClient.js
@@ -1,0 +1,193 @@
+/*!
+ * Copyright (c) 2025 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as bedrock from '@bedrock/core';
+import {readFile, stat} from 'node:fs/promises';
+import {convert} from 'html-to-text';
+import ejs from 'ejs';
+import {logger} from './logger.js';
+import {LRUCache as LRU} from 'lru-cache';
+import nodemailer from 'nodemailer';
+import path from 'node:path';
+import previewEmail from 'preview-email';
+import process from 'node:process';
+
+const {BedrockError} = bedrock.util;
+
+// load config defaults
+import './config.js';
+
+const COMPONENTS = ['subject', 'html', 'text'];
+
+// do not cache in development/test mode
+const env = (process.env.NODE_ENV ?? 'development').toLowerCase();
+const CACHE = ['development', 'test'].includes(env) ?
+  undefined : new LRU({max: 100});
+
+const TEMPLATE_EXTENSION = 'ejs';
+
+export class EmailClient {
+  constructor({
+    transport,
+    templateRootPath,
+    send = false,
+    preview = false,
+    // defaults for all emails
+    message = {},
+    subjectPrefix
+  } = {}) {
+    this.config = {
+      transport,
+      send,
+      preview,
+      message,
+      subjectPrefix,
+      templateRootPath,
+      htmlToText: {
+        selectors: [{selector: 'img', format: 'skip'}]
+      }
+    };
+
+    // send disabled; ensure JSONTransport is used
+    if(!this.config.send) {
+      this.config.transport = nodemailer.createTransport({jsonTransport: true});
+    }
+  }
+
+  async renderMessage({template, locals = {}, message} = {}) {
+    // initialize message
+    message = {...message};
+    COMPONENTS.forEach(c => c in message ? undefined : message[c] = undefined);
+
+    // render and update all message components w/ given template
+    if(template) {
+      await Promise.all(COMPONENTS.map(async component => {
+        const result = await this._renderComponent({
+          template, component, locals
+        });
+        if(result) {
+          message[component] = result;
+        }
+      }));
+    }
+
+    if(message.subject) {
+      if(this.config.subjectPrefix) {
+        message.subject = this.config.subjectPrefix + message.subject;
+      }
+      message.subject = message.subject.trim();
+    }
+
+    // if no `text` is present, produce it from html
+    if(message.html && !message.text) {
+      message.text = convert(message.html, this.config.htmlToText).trim();
+    }
+
+    // throw error for totally blank message
+    if(!(message.subject || message.html || message.text ||
+      message.attachments.length > 0)) {
+      const error = new BedrockError(
+        `No message content detected for template "${template}"; ` +
+        '(no "subject", "html", "text", nor "attachments").', {
+          name: 'DataError'
+        });
+      logger.error('Empty email detected and not sent.', {error});
+      throw error;
+    }
+
+    return message;
+  }
+
+  async send(options = {}) {
+    const {template = ''} = options;
+    const locals = {
+      ...this.config.views.locals,
+      ...options.locals
+    };
+
+    // construct fully rendered message
+    let message = {
+      ...this.config.message,
+      ...options.message,
+      attachments: options.message.attachments ??
+        this.config.message.attachments ?? []
+    };
+    message = await this.renderMessage(template, locals, message);
+
+    // preview email in a browser
+    if(this.config.preview) {
+      await (typeof this.config.preview === 'object' ?
+        previewEmail(message, this.config.preview) :
+        previewEmail(message));
+    }
+
+    // send message
+    const result = await this.config.transport.sendMail(message);
+    result.originalMessage = message;
+    return result;
+  }
+
+  // convert a template name to a full file path
+  _getTemplateFilePath({templateName} = {}) {
+    // `templateName` format is either:
+    // 1. absolute file path w/o the extension
+    // 2. <templateName>/<subject|html|text>
+    const [root, basename] = path.isAbsolute(templateName) ?
+      [path.dirname(templateName), path.basename(templateName)] :
+      [this.config.templateRootPath, templateName];
+    return path.join(root, basename, TEMPLATE_EXTENSION);
+  }
+
+  // render a template file
+  async _render({filePath, locals = {}} = {}) {
+    // get cached compiled template/compile template
+    let renderFn = this.config.cache ?? CACHE.get(filePath);
+    if(!renderFn) {
+      try {
+        const content = await readFile(filePath, 'utf8');
+        renderFn = ejs.compile(content, {async: true});
+      } catch(cause) {
+        const error = new BedrockError(
+          `Could not compile email template "${filePath}": ${cause.message}`, {
+            name: 'OperationError',
+            cause
+          });
+        logger.error('Could not compile email template', {error});
+        throw error;
+      }
+    }
+
+    return renderFn(filePath, locals);
+  }
+
+  // renders a component of a message, if a template file for it exists
+  async _renderComponent({template, component, locals = {}} = {}) {
+    // template name format is: <template>/<subject|html|text>
+    const templateName = path.join(template, component);
+    const filePath = this._getTemplateFilePath({templateName});
+    const exists = await this._templateFileExists({filePath});
+    if(!exists) {
+      return;
+    }
+    return this._render({filePath, locals});
+  }
+
+  async _templateFileExists({templateName, component} = {}) {
+    try {
+      const name = path.join(templateName, component);
+      const filePath = this.getTemplatePath({templateName: name});
+      const stats = await stat(filePath);
+      if(!stats.isFile()) {
+        const error = new BedrockError(
+          `Template "${filePath}" is not a file.`, {
+            name: 'OperationError'
+          });
+        logger.error(`Template "${filePath}" is not a file.`, {error});
+        throw error;
+      }
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
 /*!
- * Copyright (c) 2012-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2012-2025 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import appRoot from 'app-root-path';
-import Email from 'email-templates';
+import {EmailClient} from './EmailClient.js';
+import {logger} from './logger.js';
 import nodemailer from 'nodemailer';
 import path from 'node:path';
 
@@ -14,8 +15,6 @@ import './config.js';
 
 // email client
 let client;
-
-const logger = bedrock.loggers.get('app').child('bedrock-mail');
 
 bedrock.events.on('bedrock-cli.init', async () => {
   bedrock.program.option('--mail-to <address>',
@@ -34,11 +33,6 @@ bedrock.events.on('bedrock-cli.init', async () => {
     ' (true/t/1, false/f/0, default).',
     /^(true|t|1|false|f|0|default)$/i, 'default');
 });
-
-function _b(value) {
-  const v = value.toString().toLowerCase();
-  return (v === true || v === 'true' || v === 't' || v === '1');
-}
 
 bedrock.events.on('bedrock-cli.ready', async () => {
   const opts = bedrock.program.opts();
@@ -83,6 +77,11 @@ async function init() {
   if(!client) {
     logger.debug('no transport configured during init');
   }
+}
+
+function _b(value) {
+  const v = value.toString().toLowerCase();
+  return (v === true || v === 'true' || v === 't' || v === '1');
 }
 
 async function _useTransport(transportConfig) {
@@ -131,33 +130,30 @@ async function _useTransport(transportConfig) {
     }
   }
 
-  let viewsRoot;
+  let templateRootPath;
   if(cfg.templates.paths.length > 1) {
     throw new BedrockError(
-      'Only one templates path currently supported.',
-      'InvalidConfiguration', {
-        paths: cfg.templates.paths
+      'Only one template path currently supported.', {
+        name: 'NotSupportedError',
+        details: {
+          paths: cfg.templates.paths
+        }
       });
   } else if(cfg.templates.paths.length === 1) {
-    viewsRoot = cfg.templates.paths[0];
+    templateRootPath = cfg.templates.paths[0];
   } else {
-    viewsRoot = path.join(appRoot.toString(), 'emails');
+    templateRootPath = path.join(appRoot.toString(), 'emails');
   }
-  logger.info('views root', {path: viewsRoot});
+  logger.info('template root path', {path: templateRootPath});
 
-  client = new Email({
+  client = new EmailClient({
     transport,
-    message: cfg.message,
-    preview: cfg.preview,
+    templateRootPath,
     send: cfg.send,
+    preview: cfg.preview,
+    // message defaults for all emails
+    message: cfg.message,
     subjectPrefix: cfg.subjectPrefix,
-    views: {
-      root: viewsRoot,
-      options: {
-        // FIXME: allow changing template engine
-        extension: 'ejs'
-      }
-    }
   });
   logger.debug('transport configured');
 }
@@ -178,36 +174,12 @@ export async function use(property, ...args) {
     case 'transport':
       return _useTransport(args[0]);
     default:
-      throw new BedrockError(
-        'Unknown configuration property.',
-        'InvalidConfiguration', {
+      throw new BedrockError('Unknown configuration property.', {
+        name: 'NotSupportedError',
+        details: {
           property
-        });
-  }
-}
-
-/**
- * Verifies client connection (if supported).
- *
- * @returns {Promise<object>} The verify status:
- *   {verified: <boolean>[, error: <Error>]}.
- */
-export async function verify() {
-  try {
-    if(!client) {
-      throw new BedrockError(
-        'Unconfigured transport.',
-        'InvalidConfiguration');
-    }
-    client.verify();
-    return {
-      verified: true
-    };
-  } catch(e) {
-    return {
-      verified: false,
-      error: e
-    };
+        }
+      });
   }
 }
 
@@ -222,35 +194,33 @@ export async function verify() {
  *
  * @returns {Promise<object>} The details of the message sent.
  */
-export async function send({template, message, locals}) {
+export async function send({template, message, locals} = {}) {
   const cfg = bedrock.config.mail;
 
   if(!client) {
-    // FIXME: log warning?
+    logger.debug('Warning, send() called before "client" initialized.');
     return;
   }
-  // FIXME: add custom config.mail.templates.paths multi-path template lookup
-  // if template option not absolute
-  // FIXME: shallow? deep? let caller do it?
-  const _locals = {...cfg.locals, ...locals};
+
   // handle to field override
   if(cfg.to) {
-    // FIXME: add original email in header?
     message = {...message, ...{to: cfg.to}};
   }
+
   const result = await client.send({
     template,
     message,
-    locals: _locals
+    locals: {...cfg.locals, ...locals}
   });
+
   // minimal email info
-  // FIXME: what to log? what level? seperate mail log? event?
   logger.debug('sent', {
     messageId: result.messageId,
     from: result.envelope.from,
     to: result.envelope.to,
     subject: result.originalMessage.subject
   });
+
   // more verbose configured logging
   if(cfg.log.headers || cfg.log.text || cfg.log.html) {
     let msg = 'sent email:\n';
@@ -274,4 +244,24 @@ export async function send({template, message, locals}) {
     logger.info(msg);
   }
   return result;
+}
+
+/**
+ * Verifies client connection (if supported).
+ *
+ * @returns {Promise<object>} The verify status:
+ *   {verified: <boolean>[, error: <Error>]}.
+ */
+export async function verify() {
+  try {
+    if(!client) {
+      throw new BedrockError('Unconfigured transport.', {
+        name: 'OperationError'
+      });
+    }
+    await client.verify();
+    return {verified: true};
+  } catch(error) {
+    return {verified: false, error};
+  }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2025 Digital Bazaar, Inc. All rights reserved.
+ */
+import {loggers} from '@bedrock/core';
+
+export const logger = loggers.get('app').child('bedrock-mail');

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   "dependencies": {
     "app-root-path": "^3.1.0",
     "ejs": "^3.1.10",
-    "email-templates": "^12.0.1",
-    "nodemailer": "^6.9.15"
+    "html-to-text": "^9.0.5",
+    "lru-cache": "^11.2.1",
+    "nodemailer": "^6.9.15",
+    "preview-email": "^3.1.0"
   },
   "peerDependencies": {
     "@bedrock/core": "^6.0.0"

--- a/test/README.md
+++ b/test/README.md
@@ -11,7 +11,7 @@ simulates sending a secret code to an email address.
 - Account details are looked up, including name and email.
 - URL for code is created.
 - QR Code (PNG and Text) are created.
-- Mail API is called to send email using a template 
+- Mail API is called to send email using a template
 
 To run the app, either use defaults and the email will be previewed.
 
@@ -44,9 +44,9 @@ node index.js --config my-send.js
 To override pieces while testing, use `--help` to see all options:
 
 ```
-node index.js --config my-send.js --account demo
+node index.js --config my-send.js --account default
 node index.js --config my-send.js --mail-to me@example.com
-node index.js --config my-send.js --account demo --mail-preview true --mail-send false
+node index.js --config my-send.js --account default --mail-preview true --mail-send false
 ```
 
 ## Template Testing


### PR DESCRIPTION
@davidlehn, this PR removes the massive bundle of dependencies for templates that weren't even configurable/usable with this package. Instead, we install `ejs` and use it directly.

I walked through our existing implementation and reworked everything to continue supporting everything that I believe we were supporting before. That being said, we could go to a new major version to avoid any possible trouble. Let me know what you think.

This still needs testing, so I'm marking it as a draft PR until that's sorted; help wanted.