### PR TITLE
Use `nodemailer@7`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,18 @@
 ## 7.2.0 - 2025-mm-dd
 
 ### Changed
-- **BREAKING**: Workaround a vulnerability in `nodemailer` as imported into
-  `preview-email` by making `preview-email` an optional peer dependency. This
-  library is only used to preview emails, typically while using a CLI command
-  to test what emails look like prior to adding them to some deployed system.
-- **BREAKING**: Fix a vulnerability in the `nodemailer` dependency by
-  upgrading to a new major version of that package (v7), which drops support
-  for transports that use AWS SESv1, requiring replacements that use at
-  least AWS SESv2. AES SESv2 is a replacement for SESv1 that was released
-  in 2020.
+- **BREAKING**: This change is breaking but done to address a vulnerability
+  and not likely to actually have breaking impact: Workaround a vulnerability
+  in `nodemailer` as imported into `preview-email` by making `preview-email`
+  an optional peer dependency. This library is only used to preview emails,
+  typically while using a CLI command to test what emails look like prior to
+  adding them to some deployed system.
+- **BREAKING**: This change is breaking but done to address a vulnerability
+  and not likely to actually have breaking impact: Fix a vulnerability in the
+  `nodemailer` dependency by upgrading to a new major version of that package
+  (v7), which drops support for transports that use AWS SESv1, requiring
+  replacements that use at least AWS SESv2. AES SESv2 is a replacement for
+  SESv1 that was released in 2020.
 
 ## 7.0.0 - 2025-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # bedrock-mail ChangeLog
 
+## 7.1.0 - 2025-mm-dd
+
+### Fixed
+- **BREAKING**: Fix a vulnerability in the `nodemailer` dependency by
+  upgrading to a new major version of that package (v7), which drops support
+  for transports that use AWS SESv1, requiring replacements that use at
+  least AWS SESv2. AES SESv2 is a replacement for SESv1 that was released
+  in 2020.
+
 ## 7.0.0 - 2025-09-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # bedrock-mail ChangeLog
 
-## 7.1.0 - 2025-mm-dd
+## 7.2.0 - 2025-mm-dd
 
-### Fixed
+### Changed
+- **BREAKING**: Workaround a vulnerability in `nodemailer` as imported into
+  `preview-email` by making `preview-email` an optional peer dependency. This
+  library is only used to preview emails, typically while using a CLI command
+  to test what emails look like prior to adding them to some deployed system.
 - **BREAKING**: Fix a vulnerability in the `nodemailer` dependency by
   upgrading to a new major version of that package (v7), which drops support
   for transports that use AWS SESv1, requiring replacements that use at

--- a/lib/EmailClient.js
+++ b/lib/EmailClient.js
@@ -9,7 +9,6 @@ import {logger} from './logger.js';
 import {LRUCache as LRU} from 'lru-cache';
 import nodemailer from 'nodemailer';
 import path from 'node:path';
-import previewEmail from 'preview-email';
 import process from 'node:process';
 
 const {BedrockError} = bedrock.util;
@@ -25,6 +24,8 @@ const CACHE = ['development', 'test'].includes(env) ?
   undefined : new LRU({max: 100});
 
 const TEMPLATE_EXTENSION = '.ejs';
+
+let previewEmail;
 
 export class EmailClient {
   constructor({
@@ -113,6 +114,17 @@ export class EmailClient {
 
     // preview email in a browser
     if(this.config.preview) {
+      if(!previewEmail) {
+        try {
+          const mod = await import('preview-email');
+          previewEmail = mod.default;
+        } catch(error) {
+          logger.error(
+            'Could not load optional dependency "preview-email" required ' +
+            'to preview email; is it installed?', {error});
+          throw error;
+        }
+      }
       await (typeof this.config.preview === 'object' ?
         previewEmail(message, this.config.preview) :
         previewEmail(message));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ejs": "^3.1.10",
     "html-to-text": "^9.0.5",
     "lru-cache": "^11.2.1",
-    "nodemailer": "^6.9.15",
+    "nodemailer": "^7.0.9",
     "preview-email": "^3.1.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,16 @@
     "ejs": "^3.1.10",
     "html-to-text": "^9.0.5",
     "lru-cache": "^11.2.1",
-    "nodemailer": "^7.0.9",
-    "preview-email": "^3.1.0"
+    "nodemailer": "^7.0.9"
   },
   "peerDependencies": {
-    "@bedrock/core": "^6.0.0"
+    "@bedrock/core": "^6.0.0",
+    "preview-email": "^3.1.0"
+  },
+  "peerDependenciesMeta": {
+    "preview-email": {
+      "optional": true
+    }
   },
   "directories": {
     "lib": "./lib"

--- a/test/package.json
+++ b/test/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@bedrock/core": "^6.0.0",
     "@bedrock/mail": "file:..",
+    "preview-email": "^3.1.0",
     "qrcode": "^1.4.4"
   }
 }


### PR DESCRIPTION
The `preview-email` dependency still uses `nodemailer@6` that includes a vulnerability -- one that will not actually be triggered by that package, but hopefully there will be an update to that package soon.